### PR TITLE
Cleaned config file and display from name correctly

### DIFF
--- a/config/mail.global.php.dist
+++ b/config/mail.global.php.dist
@@ -27,10 +27,6 @@ return [
 
             'transport' => Symfony\Component\Mailer\Transport\Smtp\SmtpTransport::class,
 
-            // Uncomment the below line if you want to save a copy of all sent emails to a certain IMAP folder
-            // Valid only if the Transport is SMTP
-            //'save_sent_message_folder' => ['INBOX.Sent'],
-
             //message configuration
             'message_options' => [
 

--- a/config/mail.global.php.dist
+++ b/config/mail.global.php.dist
@@ -25,7 +25,7 @@ return [
              * defaults to sendmail
              **/
 
-            'transport' => Symfony\Component\Mailer\Transport\Smtp\SmtpTransport::class,
+            'transport' => Symfony\Component\Mailer\Transport\SendmailTransport::class,
 
             //message configuration
             'message_options' => [
@@ -98,14 +98,6 @@ return [
                     //null should be used to disable SSL
                     'ssl' => 'tls',
                 ]
-            ],
-
-            //listeners to register with the mail service, for mail events
-            'event_listeners' => [
-                //[
-                    //'type' => 'service or class name',
-                    //'priority' => 1
-                //],
             ],
         ],
         // option to log the SENT emails

--- a/docs/book/v4/transports.md
+++ b/docs/book/v4/transports.md
@@ -9,7 +9,7 @@
 
 > Feel free to use any custom transport you desire, provided it implements the mentioned `TransportInterface`.
 
-`Sendmail` is a wrapper over PHP's `mail()` function, and as such has a different behaviour on Windows than on *nix systems. Using sendmail on Windows **will not work in combination with** `addBcc()`.
+PHP's `mail()` function is a wrapper over `Sendmail`, and as such has a different behaviour on Windows than on *nix systems. Using sendmail on Windows **will not work in combination with** `addBcc()`.
 
 - Note: emails sent using the sendmail transport will be more often delivered to SPAM.
 

--- a/docs/book/v4/transports.md
+++ b/docs/book/v4/transports.md
@@ -9,7 +9,7 @@
 
 > Feel free to use any custom transport you desire, provided it implements the mentioned `TransportInterface`.
 
-PHP's `mail()` function is a wrapper over `Sendmail`, and as such has a different behaviour on Windows than on *nix systems. Using sendmail on Windows **will not work in combination with** `addBcc()`.
+`Sendmail` is a wrapper over PHP's `mail()` function, and as such has a different behaviour on Windows than on *nix systems. Using sendmail on Windows **will not work in combination with** `addBcc()`.
 
 - Note: emails sent using the sendmail transport will be more often delivered to SPAM.
 

--- a/docs/book/v5/configuration.md
+++ b/docs/book/v5/configuration.md
@@ -27,13 +27,6 @@ Sending email with the `Smtp` transport requires valid data for the values under
 
 > The configured path must be a writable directory
 
-```php
-'file_options' => [
-    'path' => 'data/mail/output',
-    //'callback' => null,
-],
-```
-
 ## Logging configuration
 
 Uncommenting the `dot-mail.log` key will save a copy of all sent emails' subject, recipient addresses, cc and bcc addresses alongside a timestamp.

--- a/docs/book/v5/transports.md
+++ b/docs/book/v5/transports.md
@@ -7,7 +7,7 @@
 
 > Feel free to use any custom transport you desire, provided it implements the mentioned `TransportInterface`.
 
-`Sendmail` is a wrapper over PHP's `mail()` function, and as such has a different behaviour on Windows than on *nix systems. Using sendmail on Windows **will not work in combination with** `addBcc()`.
+PHP's `mail()` function is a wrapper over `Sendmail`, and as such has a different behaviour on Windows than on *nix systems. Using sendmail on Windows **will not work in combination with** `addBcc()`.
 
 - Note: emails sent using the sendmail transport will be more often delivered to SPAM.
 

--- a/src/Factory/MailServiceAbstractFactory.php
+++ b/src/Factory/MailServiceAbstractFactory.php
@@ -111,7 +111,7 @@ class MailServiceAbstractFactory extends AbstractMailFactory
 
         $from = $options->getFrom();
         if (! empty($from)) {
-            $message->addFrom($from);
+            $message->addFrom($from, $options->getFromName());
         }
 
         $replyTo = $options->getReplyTo();

--- a/test/CommonTrait.php
+++ b/test/CommonTrait.php
@@ -60,11 +60,6 @@ trait CommonTrait
                      **/
                     'transport' => SmtpTransport::class,
 
-                    // Uncomment the below line if you want to save a copy of all sent emails to a certain IMAP folder
-                    // Valid only if the Transport is SMTP
-                    // 'save_sent_message_folder' => ['INBOX.Sent'],
-
-                    // Uncomment the below line if you want to save a copy of all sent emails to a certain IMAP folder
                     // Valid only if the Transport is SMTP
                     'save_sent_message_folder' => ['INBOX.Sent'],
                     'message_options'          => [
@@ -105,14 +100,6 @@ trait CommonTrait
                             'password' => 'qwd',
                             'ssl'      => 'tls',
                         ],
-                    ],
-
-                    //listeners to register with the mail service, for mail events
-                    'event_listeners' => [
-                        //[
-                        //'type' => 'service or class name',
-                        //'priority' => 1
-                        //],
                     ],
                 ],
                 // option to log the SENT emails


### PR DESCRIPTION
I cleaned the config file, updated the documentation for v5, fixed from_name not displayed correctly. 
Issue #60 