### PR TITLE
MailService - fix email structure with multiple attachments

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -96,18 +96,19 @@ class MailService implements MailServiceInterface, MailEventListenerAwareInterfa
             return false;
         }
 
-        $mimeMessage = $this->message->getBody();
+        $body  = $this->message->getBody();
+        $parts = [];
 
-        //generate a new Part for each attachment
         foreach ($this->attachments as $key => $attachment) {
             if (! is_file($attachment)) {
                 continue;
             }
-            $basename     = is_string($key) ? $key : basename($attachment);
-            $attachedFile = new DataPart(fopen($attachment, 'r'), $basename);
-            $mimeMessage  = new MixedPart($mimeMessage, $attachedFile);
+            $basename = is_string($key) ? $key : basename($attachment);
+            $parts[]  = new DataPart(fopen($attachment, 'r'), $basename);
+        }
 
-            $this->message->setBody($mimeMessage);
+        if (count($parts) > 0) {
+            $this->message->setBody(new MixedPart($body, ...$parts));
         }
 
         return $this->message;

--- a/test/Service/MailServiceTest.php
+++ b/test/Service/MailServiceTest.php
@@ -236,7 +236,8 @@ class MailServiceTest extends TestCase
 
         $this->mailService->attachFiles();
 
-        $body  = $this->message->getBody();
+        $body = $this->message->getBody();
+        $this->assertInstanceOf(MixedPart::class, $body);
         $parts = $body->getParts();
 
         $this->assertCount(2, $parts);
@@ -282,7 +283,8 @@ class MailServiceTest extends TestCase
 
         $this->mailService->attachFiles();
 
-        $body  = $this->message->getBody();
+        $body = $this->message->getBody();
+        $this->assertInstanceOf(MixedPart::class, $body);
         $parts = $body->getParts();
 
         // None of the children should be a MixedPart (no nesting)

--- a/test/Service/MailServiceTest.php
+++ b/test/Service/MailServiceTest.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\TextPart;
 
 class MailServiceTest extends TestCase
@@ -152,5 +154,140 @@ class MailServiceTest extends TestCase
         $this->assertInstanceOf(MailResult::class, $mailResult);
         $this->assertSame($customException, $mailResult->getException());
         $this->assertSame('Custom exception test', $mailResult->getMessage());
+    }
+
+    public function testAttachFilesReturnsFalseWhenNoAttachments(): void
+    {
+        $this->message->html('Test body');
+        $result = $this->mailService->attachFiles();
+        $this->assertFalse($result);
+    }
+
+    public function testAttachFilesCreatesFlatMixedPart(): void
+    {
+        $this->message->html('<p>Test</p>');
+
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testPdfAttachment.pdf'
+        );
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testXlsAttachment.xls'
+        );
+
+        $this->mailService->attachFiles();
+
+        $body = $this->message->getBody();
+        $this->assertInstanceOf(MixedPart::class, $body);
+
+        $parts = $body->getParts();
+        // 1 TextPart (html) + 2 DataParts (attachments) = 3 parts at same level
+        $this->assertCount(3, $parts);
+        $this->assertInstanceOf(TextPart::class, $parts[0]);
+        $this->assertInstanceOf(DataPart::class, $parts[1]);
+        $this->assertInstanceOf(DataPart::class, $parts[2]);
+    }
+
+    public function testAttachFilesSingleAttachmentIsFlat(): void
+    {
+        $this->message->html('<p>Single attachment</p>');
+
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testPdfAttachment.pdf'
+        );
+
+        $this->mailService->attachFiles();
+
+        $body = $this->message->getBody();
+        $this->assertInstanceOf(MixedPart::class, $body);
+
+        $parts = $body->getParts();
+        $this->assertCount(2, $parts);
+        $this->assertInstanceOf(TextPart::class, $parts[0]);
+        $this->assertInstanceOf(DataPart::class, $parts[1]);
+    }
+
+    public function testAttachFilesSkipsNonExistentFiles(): void
+    {
+        $this->message->html('<p>Test</p>');
+
+        $this->mailService->addAttachment('/nonexistent/file.pdf');
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testPdfAttachment.pdf'
+        );
+
+        $this->mailService->attachFiles();
+
+        $body = $this->message->getBody();
+        $this->assertInstanceOf(MixedPart::class, $body);
+
+        $parts = $body->getParts();
+        // only 1 valid attachment + the html body
+        $this->assertCount(2, $parts);
+    }
+
+    public function testAttachFilesPreservesCustomFilename(): void
+    {
+        $this->message->html('<p>Test</p>');
+
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testPdfAttachment.pdf',
+            'custom-ticket.pdf'
+        );
+
+        $this->mailService->attachFiles();
+
+        $body  = $this->message->getBody();
+        $parts = $body->getParts();
+
+        $this->assertCount(2, $parts);
+        $attachment = $parts[1];
+        $this->assertInstanceOf(DataPart::class, $attachment);
+        $this->assertSame('custom-ticket.pdf', $attachment->getFilename());
+    }
+
+    public function testAttachFilesWithTextPartBody(): void
+    {
+        $textPart = new TextPart('<h1>HTML content</h1>', 'utf-8', 'html');
+        $this->mailService->setBody($textPart);
+
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testPdfAttachment.pdf'
+        );
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testXlsAttachment.xls'
+        );
+
+        $this->mailService->attachFiles();
+
+        $body = $this->message->getBody();
+        $this->assertInstanceOf(MixedPart::class, $body);
+
+        $parts = $body->getParts();
+        $this->assertCount(3, $parts);
+        $this->assertInstanceOf(TextPart::class, $parts[0]);
+        $this->assertInstanceOf(DataPart::class, $parts[1]);
+        $this->assertInstanceOf(DataPart::class, $parts[2]);
+    }
+
+    public function testAttachFilesNoNestedMixedParts(): void
+    {
+        $this->message->html('<p>Test nesting</p>');
+
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testPdfAttachment.pdf'
+        );
+        $this->mailService->addAttachment(
+            $this->fileSystem->url() . '/data/mail/attachments/testXlsAttachment.xls'
+        );
+
+        $this->mailService->attachFiles();
+
+        $body  = $this->message->getBody();
+        $parts = $body->getParts();
+
+        // None of the children should be a MixedPart (no nesting)
+        foreach ($parts as $part) {
+            $this->assertNotInstanceOf(MixedPart::class, $part);
+        }
     }
 }


### PR DESCRIPTION
Outlook has problems sending emails, when there are multiple attachments.

"Expected response code "250" but got code "554", with message "554 5.6.0 Invalid message content when handling MIME exception. IMC53"

Analyzing generated email files found out, that there are problems with structure - old code nests each attachment on top of previous one.

**Structure was**
Content-Type: multipart/mixed; boundary=Btd1YvhJ        ← level 1
  Content-Type: multipart/mixed; boundary=rsZ9uNfm      ← level 2 (WHY?)
    Content-Type: multipart/mixed; boundary=sYDuS8mW    ← level 3 (WHY?)
      text/html (body)
      PDF attachment
    other attachment 9012
  other attachment 9013

**Structure after fix**
multipart/mixed; boundary=XXX
  text/html (body)
  PDF attachment
  other attachment 9012
  other attachment 9013


After exploration there was conclusion about old solution:
Not strictly invalid per MIME RFC — but result has multipart/mixed inside multipart/mixed

The inner multipart only groups:
HTML body
one PDF
Then another attachment exists outside that group

This structure is redundant and irregular, and Outlook is known to behave unpredictably with nested multipart/mixed blocks like this.